### PR TITLE
fix: Resolve contact names in chats and messages

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -217,7 +217,7 @@ export function getChats(
     let sql = `
             SELECT
                 c.jid,
-                c.name,
+                COALESCE(c.name, ct.name, ct.notify, ct.phone_number) as name,
                 c.last_message_time
                 ${
                   includeLastMessage
@@ -229,19 +229,20 @@ export function getChats(
                     : ""
                 }
             FROM chats c
+            LEFT JOIN contacts ct ON c.jid = ct.jid
         `;
 
     const params: (string | number)[] = [];
 
     if (query) {
-      sql += ` WHERE (LOWER(c.name) LIKE LOWER(?) OR c.jid LIKE ?)`;
+      sql += ` WHERE (LOWER(COALESCE(c.name, ct.name, ct.notify, ct.phone_number)) LIKE LOWER(?) OR c.jid LIKE ?)`;
       params.push(`%${query}%`, `%${query}%`);
     }
 
     const orderByClause =
       sortBy === "last_active"
         ? "c.last_message_time DESC NULLS LAST"
-        : "c.name ASC";
+        : "COALESCE(c.name, ct.name, ct.notify, ct.phone_number) ASC";
     sql += ` ORDER BY ${orderByClause}, c.jid ASC`;
 
     sql += ` LIMIT ? OFFSET ?`;
@@ -265,7 +266,7 @@ export function getChat(
     let sql = `
             SELECT
                 c.jid,
-                c.name,
+                COALESCE(c.name, ct.name, ct.notify, ct.phone_number) as name,
                 c.last_message_time
                 ${
                   includeLastMessage
@@ -277,6 +278,7 @@ export function getChat(
                     : ""
                 }
             FROM chats c
+            LEFT JOIN contacts ct ON c.jid = ct.jid
             WHERE c.jid = ? -- Positional parameter 1
         `;
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -387,7 +387,7 @@ export function searchDbForContacts(
 
 export function searchMessages(
   searchQuery: string,
-  chatJid?: string | null, 
+  chatJid?: string | null,
   limit: number = 10,
   page: number = 0,
 ): Message[] {
@@ -396,26 +396,27 @@ export function searchMessages(
     const offset = page * limit;
     const searchPattern = `%${searchQuery}%`;
     let sql = `
-            SELECT m.*, c.name as chat_name
+            SELECT m.*, COALESCE(c.name, ct.name, ct.notify, ct.phone_number) as chat_name
             FROM messages m
             JOIN chats c ON m.chat_jid = c.jid
+            LEFT JOIN contacts ct ON c.jid = ct.jid
             WHERE LOWER(m.content) LIKE LOWER(?) -- Param 1: searchPattern
         `;
     const params: (string | number | null)[] = [searchPattern];
 
     if (chatJid) {
-      sql += ` AND m.chat_jid = ?`; 
+      sql += ` AND m.chat_jid = ?`;
       params.push(chatJid);
     }
 
     sql += ` ORDER BY m.timestamp DESC`;
     sql += ` LIMIT ?`;
     params.push(limit);
-    sql += ` OFFSET ?`; 
+    sql += ` OFFSET ?`;
     params.push(offset);
 
     const stmt = db.prepare(sql);
-    const rows = stmt.all(...params) as any[]; 
+    const rows = stmt.all(...params) as any[];
     return rows.map(rowToMessage);
   } catch (error) {
     console.error("Error searching messages:", error);


### PR DESCRIPTION
## Summary

- Resolve contact names for private chats in `getChats`, `getChat`, and `searchMessages` functions
- Uses `LEFT JOIN` with contacts table to look up names when chat name is missing
- Falls back through: `chat.name` → `contact.name` → `notify` → `phone_number`

This fixes the issue where private chats would show JIDs instead of contact names.

## Test plan

- [ ] Verify `getChats` returns resolved contact names for private chats
- [ ] Verify `getChat` returns resolved contact name for a private chat
- [ ] Verify `searchMessages` shows resolved chat names in results
- [ ] Verify search by name works with resolved contact names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat name resolution by incorporating associated contact information for better accuracy across chat listings and message search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->