### PR TITLE
fix: prevent memory leak from orphaned sockets on reconnect

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -94,6 +94,14 @@ function parseMessageForDb(msg: WAMessage): DbMessage | null {
   };
 }
 
+/**
+ * Open a self-healing WhatsApp connection.
+ *
+ * Returns a stable handle (a Proxy) that always delegates to the live socket: on
+ * a non-logout disconnect the underlying socket is torn down and transparently
+ * re-established with exponential backoff, so callers may hold the returned value
+ * for the process lifetime without ever referencing a dead socket.
+ */
 export async function startWhatsAppConnection(
   logger: P.Logger
 ): Promise<WhatsAppSocket> {
@@ -116,7 +124,7 @@ export async function startWhatsAppConnection(
   // (thousands of `timedOut` closes per minute) accumulated orphaned sockets --
   // each with its own WebSocket, keep-alive timer and signal-key cache -- leaking
   // memory until the process grew to multiple GB.
-  let currentSock: WhatsAppSocket = null as any;
+  let currentSock: WhatsAppSocket | null = null;
   let detach: (() => void) | null = null;
   let reconnecting = false;
   let attempts = 0;
@@ -124,6 +132,10 @@ export async function startWhatsAppConnection(
   const MAX_DELAY_MS = 30_000;
 
   const teardown = (dead: WhatsAppSocket) => {
+    // Stop exposing the dying socket through the proxy until we reconnect.
+    if (currentSock === dead) {
+      currentSock = null;
+    }
     try {
       detach?.();
     } catch {}
@@ -294,10 +306,12 @@ export async function startWhatsAppConnection(
   // captured at startup.
   const handle = new Proxy({} as WhatsAppSocket, {
     get(_target, prop) {
+      if (!currentSock) return undefined;
       const value = (currentSock as any)[prop];
       return typeof value === "function" ? value.bind(currentSock) : value;
     },
     set(_target, prop, value) {
+      if (!currentSock) return true;
       (currentSock as any)[prop] = value;
       return true;
     },

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -103,18 +103,63 @@ export async function startWhatsAppConnection(
   const { version, isLatest } = await fetchLatestBaileysVersion();
   logger.info(`Using WA v${version.join(".")}, isLatest: ${isLatest}`);
 
-  const sock = makeWASocket({
-    version,
-    logger,
-    auth: {
-      creds: state.creds,
-      keys: makeCacheableSignalKeyStore(state.keys, logger),
-    },
-    generateHighQualityLinkPreview: true,
-    shouldIgnoreJid: (jid) => isJidGroup(jid),
-  });
+  // One logical connection that transparently re-establishes itself.
+  //
+  // `currentSock` always points at the live socket; the Proxy returned at the end
+  // forwards to it, so callers never end up holding a stale, disconnected socket
+  // after a reconnect.
+  //
+  // Reconnects are guarded with a single-flight lock, exponential backoff and an
+  // explicit teardown of the dying socket. Previously every "close" recursively
+  // called startWhatsAppConnection() again without ending the old socket or
+  // detaching its `ev.process` handler, so a WhatsApp-side disconnect storm
+  // (thousands of `timedOut` closes per minute) accumulated orphaned sockets --
+  // each with its own WebSocket, keep-alive timer and signal-key cache -- leaking
+  // memory until the process grew to multiple GB.
+  let currentSock: WhatsAppSocket = null as any;
+  let detach: (() => void) | null = null;
+  let reconnecting = false;
+  let attempts = 0;
+  const BASE_DELAY_MS = 1_000;
+  const MAX_DELAY_MS = 30_000;
 
-  sock.ev.process(async (events) => {
+  const teardown = (dead: WhatsAppSocket) => {
+    try {
+      detach?.();
+    } catch {}
+    detach = null;
+    try {
+      dead.end(undefined);
+    } catch {}
+  };
+
+  const scheduleReconnect = (dead: WhatsAppSocket) => {
+    if (reconnecting) return; // single-flight: ignore duplicate close events
+    reconnecting = true;
+    teardown(dead);
+    const delay = Math.min(MAX_DELAY_MS, BASE_DELAY_MS * 2 ** attempts);
+    attempts++;
+    logger.info(`Reconnecting in ${delay}ms (attempt ${attempts})`);
+    setTimeout(() => {
+      reconnecting = false;
+      connect();
+    }, delay);
+  };
+
+  const connect = () => {
+    const sock = makeWASocket({
+      version,
+      logger,
+      auth: {
+        creds: state.creds,
+        keys: makeCacheableSignalKeyStore(state.keys, logger),
+      },
+      generateHighQualityLinkPreview: true,
+      shouldIgnoreJid: (jid) => isJidGroup(jid),
+    });
+    currentSock = sock;
+
+    detach = sock.ev.process(async (events) => {
     if (events["connection.update"]) {
       const update = events["connection.update"];
       const { connection, lastDisconnect, qr } = update;
@@ -137,8 +182,7 @@ export async function startWhatsAppConnection(
           lastDisconnect?.error
         );
         if (statusCode !== DisconnectReason.loggedOut) {
-          logger.info("Reconnecting...");
-          startWhatsAppConnection(logger);
+          scheduleReconnect(sock);
         } else {
           logger.error(
             "Connection closed: Logged Out. Please delete auth_info and restart."
@@ -146,8 +190,8 @@ export async function startWhatsAppConnection(
           process.exit(1);
         }
       } else if (connection === "open") {
+        attempts = 0; // reset backoff once we're actually connected
         logger.info(`Connection opened. WA user: ${sock.user?.name}`);
-        // console.log("Logged as", sock.user?.name);
       }
     }
 
@@ -240,9 +284,26 @@ export async function startWhatsAppConnection(
         });
       }
     }
+    });
+  };
+
+  connect();
+
+  // Stable handle: always delegates to the live socket, so a reconnect swaps the
+  // underlying socket transparently without invalidating references the caller
+  // captured at startup.
+  const handle = new Proxy({} as WhatsAppSocket, {
+    get(_target, prop) {
+      const value = (currentSock as any)[prop];
+      return typeof value === "function" ? value.bind(currentSock) : value;
+    },
+    set(_target, prop, value) {
+      (currentSock as any)[prop] = value;
+      return true;
+    },
   });
 
-  return sock;
+  return handle;
 }
 
 export async function sendWhatsAppMessage(


### PR DESCRIPTION
## Problem

On every non-logout disconnect, `startWhatsAppConnection()` recursively calls itself (`src/whatsapp.ts`):

```ts
if (statusCode !== DisconnectReason.loggedOut) {
  logger.info("Reconnecting...");
  startWhatsAppConnection(logger); // new socket; old one is never ended
}
```

This builds a brand-new socket **without ending the previous one or detaching its `ev.process` handler**. Under a WhatsApp-side disconnect storm (`timedOut` close events — I've observed bursts of thousands per minute), orphaned sockets pile up, each retaining its own WebSocket, keep-alive timer and signal-key cache. Memory grows unbounded — in my setup the process reached ~1.8 GB after ~10 days (peak ~2.9 GB).

There is also a **latent correctness bug**: the recursive call returns a *new* socket, but the caller (the MCP server) keeps the original reference — so after the first reconnect, `sendMessage` targets a dead socket.

## Fix

Rework the connection into a single self-healing loop:

- **Teardown** the dying socket before reconnecting — detach the `ev.process` handler (via the cleanup function it returns) and call `sock.end()` — so its resources become collectable.
- **Single-flight guard + exponential backoff** (1s → 30s, reset on `open`), so a disconnect storm can no longer spin up sockets unbounded.
- Return a **stable `Proxy`** that always delegates to the live socket, so callers keep a valid reference across reconnects.

The public API (`startWhatsAppConnection`, `sendWhatsAppMessage`) and behaviour are unchanged.

## Result

In production, a bridge that had grown to ~1.8 GB dropped to **~80–130 MB** and stayed flat across reconnects.

One file changed (`src/whatsapp.ts`); `node --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced WhatsApp connection stability with automatic reconnection and self-healing behavior
  * Improved handling of disconnects with exponential backoff and single-flight reconnection guarding
  * Prevented stale connection references so callers keep a live, transparent connection handle
  * Clearer separation of recoverable vs non-recoverable connection errors and safer cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->